### PR TITLE
fix: sessionStorage保存処理を3秒間待機するよう修正 <release/LEEAP-5058>

### DIFF
--- a/pages/magazine/index.tsx
+++ b/pages/magazine/index.tsx
@@ -3,12 +3,11 @@ import Image from "next/image";
 import Link from "next/link";
 import { handleDate } from "../../src/lib/microCMS/handleDate";
 import { CATEGORIES, TAbout, uwearAboutClient } from "../../src/lib/microCMS/uwearAboutClient";
-import { TYouTubeChannel, getYouTubeChannel } from "../../src/lib/youtube/youTubeClient";
 
 type TProps = {
   aboutData: TAbout;
   itemData: TAbout;
-  channelData: TYouTubeChannel;
+  // channelData: TYouTubeChannel;
 };
 
 export const getStaticProps = async () => {
@@ -21,18 +20,18 @@ export const getStaticProps = async () => {
     queries: { filters: `category[contains]${CATEGORIES.ITEM}` },
   });
 
-  const channelData = await getYouTubeChannel();
+  // const channelData = await getYouTubeChannel();
   return {
     props: {
       aboutData,
-      channelData,
+      // channelData,
       itemData,
     },
     revalidate: 60,
   };
 };
 
-const Magazine: NextPage<TProps> = ({ aboutData, channelData, itemData }) => {
+const Magazine: NextPage<TProps> = ({ aboutData, itemData }) => {
   return (
     <div className="min-h-screen py-4 text-themeGray">
       {aboutData && aboutData.contents.length > 0 && (
@@ -133,7 +132,7 @@ const Magazine: NextPage<TProps> = ({ aboutData, channelData, itemData }) => {
           </div>
         </>
       )}
-      <div className="mb-12 mt-36 px-6">
+      {/* <div className="mb-12 mt-36 px-6">
         <h2 className="mb-12 text-3xl">最新の動画</h2>
         <div className="mb-8 mt-4 text-sm">
           <Link
@@ -179,7 +178,7 @@ const Magazine: NextPage<TProps> = ({ aboutData, channelData, itemData }) => {
               </li>
             </Link>
           ))}
-      </ul>
+      </ul> */}
       <footer className="mt-32 text-center">UWear</footer>
     </div>
   );

--- a/pages/one-shot/moshimo.tsx
+++ b/pages/one-shot/moshimo.tsx
@@ -4,13 +4,30 @@ import { useEffect } from "react";
 
 const Moshimo: NextPage = () => {
   const router = useRouter();
-  const { rd_code } = router.query;
+  const { one_shot_rd_code } = router.query;
+
   useEffect(() => {
-    if (rd_code && rd_code === "string") {
-      sessionStorage.setItem("one_shot_rd_code", rd_code);
-    }
-    router.push("https://one.uwear.jp/");
-  }, [rd_code, router]);
+    const storeAndRedirect = async () => {
+      if (typeof one_shot_rd_code === "string") {
+        sessionStorage.setItem("one_shot_rd_code", one_shot_rd_code);
+      }
+
+      // 保存前にリダイレクトすると保存されないので、保存されたことを確認するまで待つ
+      let attempts = 0;
+      const intervalId = setInterval(() => {
+        attempts++;
+        const item = sessionStorage.getItem("one_shot_rd_code");
+
+        if (item || attempts >= 3) {
+          clearInterval(intervalId);
+          router.push("https://one.uwear.jp/");
+        }
+      }, 1000);
+    };
+
+    storeAndRedirect();
+  }, [one_shot_rd_code, router]);
+
   return <></>;
 };
 


### PR DESCRIPTION
## 要件

要件がわかるURLを貼り付けてください
https://kiizan-kiizan.atlassian.net/browse/LEEAP-5058



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - セッションストレージにアイテムを設定し、確認後にリダイレクトする新しい遅延メカニズムを導入しました。

- **リファクタ**
  - ルータークエリからの変数名を`rd_code`から`one_shot_rd_code`に変更しました。
  - セッションストレージへのアイテム設定とリダイレクトを管理する非同期関数`storeAndRedirect`を新たに導入しました。

- **バグ修正**
  - マガジンページからYouTubeチャンネル情報の取得と表示を一時的に削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->