### PR TITLE
feat: rentracksの単発用リンクと成果判定を実装 <release/LEEAP-5092-rentracks>

### DIFF
--- a/pages/one-shot/rentracks.tsx
+++ b/pages/one-shot/rentracks.tsx
@@ -1,0 +1,34 @@
+import { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+const Rentracks: NextPage = () => {
+  const router = useRouter();
+  const { rtsp } = router.query;
+
+  useEffect(() => {
+    const storeAndRedirect = async () => {
+      if (typeof rtsp === "string") {
+        sessionStorage.setItem("rtsp", rtsp);
+      }
+
+      // 保存前にリダイレクトすると保存されないので、保存されたことを確認するまで待つ
+      let attempts = 0;
+      const intervalId = setInterval(() => {
+        attempts++;
+        const item = sessionStorage.getItem("rtsp");
+
+        if (item || attempts >= 3) {
+          clearInterval(intervalId);
+          router.push("https://one.uwear.jp/");
+        }
+      }, 1000);
+    };
+
+    storeAndRedirect();
+  }, [rtsp, router]);
+
+  return <></>;
+};
+
+export default Rentracks;

--- a/pages/register/thanks.tsx
+++ b/pages/register/thanks.tsx
@@ -44,10 +44,12 @@ const Thanks: NextPage = () => {
           </div>
         </div>
       </div>
-      {/* Rentracksコンバージョンタグ */}
+      {/* アフィリエイト成果計測 */}
       {memberId && (
-        <Script id="rentracks-cv-tag" strategy="afterInteractive">
-          {`(function(){
+        <>
+          {/* Rentracksコンバージョンタグ */}
+          <Script id="rentracks-cv-tag" strategy="afterInteractive">
+            {`(function(){
        function loadScriptRTCV(callback){
        var script = document.createElement('script');
        script.type = 'text/javascript';
@@ -79,33 +81,41 @@ const Thanks: NextPage = () => {
        rt_tracktag();
        });
        }(function(){}))`}
-        </Script>
-      )}
-      {/* もしもアフィリエイトコンバージョンタグ */}
-      {memberId && sessionStorage.getItem("rd_code") && (
-        <img
-          src={`https://r.moshimo.com/af/r/result?p_id=1063&pc_id=1537&m_v=${memberId}&rd_code=${sessionStorage.getItem(
-            "rd_code",
-          )}`}
-          width="1"
-          height="1"
-          alt=""
-        />
-      )}
-      {/* 単発もしもアフィリエイトコンバージョンタグ */}
-      {memberId && sessionStorage.getItem("one_shot_rd_code") && (
-        <img
-          src={`https://r.moshimo.com/af/r/result?p_id=5688&pc_id=15710&m_v=${memberId}&rd_code=${sessionStorage.getItem(
-            "one_shot_rd_code",
-          )}`}
-          width="1"
-          height="1"
-          alt=""
-        />
-      )}
-      {/* モッピートラッキングタグ */}
-      {memberId && (
-        <>
+          </Script>
+          {/* 単発Rentracksアフィリエイトコンバージョンタグ */}
+          {sessionStorage.getItem("rtsp") && (
+            <img
+              src={`https://www.rentracks.jp/secure/es.html?sid=1847&pid=12433&price=0&quantity=1&reward=-1&cname=&ctel=&cemail=&cinfo=${memberId}&rtsp=${sessionStorage.getItem(
+                "rtsp",
+              )}`}
+              width="1"
+              height="1"
+              alt=""
+            />
+          )}
+          {/* もしもアフィリエイトコンバージョンタグ */}
+          {sessionStorage.getItem("rd_code") && (
+            <img
+              src={`https://r.moshimo.com/af/r/result?p_id=1063&pc_id=1537&m_v=${memberId}&rd_code=${sessionStorage.getItem(
+                "rd_code",
+              )}`}
+              width="1"
+              height="1"
+              alt=""
+            />
+          )}
+          {/* 単発もしもアフィリエイトコンバージョンタグ */}
+          {sessionStorage.getItem("one_shot_rd_code") && (
+            <img
+              src={`https://r.moshimo.com/af/r/result?p_id=5688&pc_id=15710&m_v=${memberId}&rd_code=${sessionStorage.getItem(
+                "one_shot_rd_code",
+              )}`}
+              width="1"
+              height="1"
+              alt=""
+            />
+          )}
+          {/* モッピートラッキングタグ */}
           <Script
             src="https://ad-track.jp/ad/js/cv.js"
             onLoad={() => {


### PR DESCRIPTION
## 要件
https://kiizan-kiizan.atlassian.net/browse/LEEAP-5092


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Rentracksという新しいNext.jsページコンポーネントを追加しました。特定のクエリパラメータを取得し、セッションストレージに保存後、指定されたURLへリダイレクトします。

- **機能改善**
  - 登録完了ページにおけるアフィリエイト成果計測タグの表示方法を改善しました。条件に応じて`img`タグを使用するように変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->